### PR TITLE
Add improvements to media service operations.

### DIFF
--- a/components/org.wso2.carbon.identity.media.core/pom.xml
+++ b/components/org.wso2.carbon.identity.media.core/pom.xml
@@ -108,23 +108,25 @@
                             org.wso2.carbon.identity.media.core.*; version="${identity.media.core.exp.pkg.version}",
                         </Export-Package>
                         <Import-Package>
-                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
-                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.media.core.file;version="${org.wso2.carbon.identity.media.core.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.media.core.jdbc;version="${org.wso2.carbon.identity.media.core.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.media.core.exception;version="${org.wso2.carbon.identity.media.core.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.media.core.model;version="${org.wso2.carbon.identity.media.core.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.media.core.util;version="${org.wso2.carbon.identity.media.core.imp.pkg.version.range}",
-                            org.wso2.carbon.user.core.service;version="${user.core.imp.pkg.version.range}",
-                            org.wso2.carbon.context;version="${user.core.imp.pkg.version.range}",
+                            org.apache.commons.collections;version="${org.apache.commons.collections.imp.pkg.version.range}",
                             org.apache.commons.io;version="${org.apache.commons.io.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.core.*;version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.apache.commons.codec.digest;version="${org.apache.commons.codec.imp.pkg.version.range}",
                             org.apache.commons.lang;version="${org.apache.commons.lang.imp.pkg.version.range}",
                             org.apache.commons.logging;version="${org.apache.commons.logging.imp.pkg.version.range}",
-                            org.apache.commons.collections;version="${org.apache.commons.collections.imp.pkg.version.range}",
                             org.json.simple,
-                            org.json.simple.parser
+                            org.json.simple.parser,
+                            org.osgi.framework;version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component;version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.context;version="${user.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core.util;version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.media.core.exception;version="${org.wso2.carbon.identity.media.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.media.core.file;version="${org.wso2.carbon.identity.media.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.media.core.jdbc;version="${org.wso2.carbon.identity.media.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.media.core.model;version="${org.wso2.carbon.identity.media.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.media.core.util;version="${org.wso2.carbon.identity.media.core.imp.pkg.version.range}",
+                            org.wso2.carbon.user.api;version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core;version="${user.core.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.common;version="${user.core.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.service;version="${user.core.imp.pkg.version.range}"
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/FileContent.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/FileContent.java
@@ -34,4 +34,6 @@ public interface FileContent extends DataContent {
     File getFile();
 
     String getResponseContentType();
+
+    String getETag();
 }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/FileContentImpl.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/FileContentImpl.java
@@ -27,18 +27,18 @@ public class FileContentImpl implements FileContent {
 
     private File file;
     private String responseContentType;
-    private String etag;
+    private String eTag;
 
     public FileContentImpl(File file) {
 
         this.file = file;
     }
 
-    public FileContentImpl(File file, String responseContentType, String etag) {
+    public FileContentImpl(File file, String responseContentType, String eTag) {
 
         this.file = file;
         this.responseContentType = responseContentType;
-        this.etag = etag;
+        this.eTag = eTag;
     }
 
     @Override
@@ -56,6 +56,6 @@ public class FileContentImpl implements FileContent {
     @Override
     public String getETag() {
 
-        return etag;
+        return eTag;
     }
 }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/FileContentImpl.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/FileContentImpl.java
@@ -27,16 +27,18 @@ public class FileContentImpl implements FileContent {
 
     private File file;
     private String responseContentType;
+    private String etag;
 
     public FileContentImpl(File file) {
 
         this.file = file;
     }
 
-    public FileContentImpl(File file, String responseContentType) {
+    public FileContentImpl(File file, String responseContentType, String etag) {
 
         this.file = file;
         this.responseContentType = responseContentType;
+        this.etag = etag;
     }
 
     @Override
@@ -49,5 +51,11 @@ public class FileContentImpl implements FileContent {
     public String getResponseContentType() {
 
         return responseContentType;
+    }
+
+    @Override
+    public String getETag() {
+
+        return etag;
     }
 }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StorageSystem.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StorageSystem.java
@@ -15,7 +15,9 @@
  */
 package org.wso2.carbon.identity.media.core;
 
+import org.wso2.carbon.identity.media.core.exception.StorageSystemClientException;
 import org.wso2.carbon.identity.media.core.exception.StorageSystemException;
+import org.wso2.carbon.identity.media.core.exception.StorageSystemServerException;
 import org.wso2.carbon.identity.media.core.model.MediaInformation;
 import org.wso2.carbon.identity.media.core.model.MediaMetadata;
 
@@ -28,23 +30,25 @@ import java.util.List;
 public interface StorageSystem {
 
     String addMedia(List<InputStream> inputStreams, MediaMetadata mediaMetadata, String uuid, String tenantDomain)
-            throws StorageSystemException;
+            throws StorageSystemServerException;
 
-    DataContent getFile(String id, String tenantDomain, String type) throws StorageSystemException;
+    DataContent getFile(String id, String tenantDomain, String type) throws StorageSystemServerException,
+            StorageSystemClientException;
 
     boolean isDownloadAllowedForPublicMedia(String id, String type, String tenantDomain) throws
-            StorageSystemException;
+            StorageSystemServerException;
 
-    boolean isDownloadAllowedForProtectedMedia(String id, String type, String tenantDomain) throws
-            StorageSystemException;
+    boolean isDownloadAllowedForProtectedMedia(String mediaId, String type, String tenantDomain, String userId) throws
+            StorageSystemServerException;
 
-    boolean isMediaManagementAllowedForEndUser(String id, String type, String tenantDomain) throws
-            StorageSystemException;
+    boolean isMediaManagementAllowedForEndUser(String mediaId, String type, String tenantDomain, String userId) throws
+            StorageSystemServerException;
 
-    void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemException;
+    void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemServerException,
+            StorageSystemClientException;
 
     MediaInformation getMediaInformation(String id, String type, String tenantDomain) throws
-            StorageSystemException;
+            StorageSystemServerException, StorageSystemClientException;
 
     InputStream transform(String id, String type, String tenantDomain, InputStream inputStream)
             throws StorageSystemException;

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StorageSystem.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StorageSystem.java
@@ -15,7 +15,6 @@
  */
 package org.wso2.carbon.identity.media.core;
 
-import org.wso2.carbon.identity.media.core.exception.StorageSystemClientException;
 import org.wso2.carbon.identity.media.core.exception.StorageSystemException;
 import org.wso2.carbon.identity.media.core.exception.StorageSystemServerException;
 import org.wso2.carbon.identity.media.core.model.MediaInformation;
@@ -32,8 +31,7 @@ public interface StorageSystem {
     String addMedia(List<InputStream> inputStreams, MediaMetadata mediaMetadata, String uuid, String tenantDomain)
             throws StorageSystemServerException;
 
-    DataContent getFile(String id, String tenantDomain, String type) throws StorageSystemServerException,
-            StorageSystemClientException;
+    DataContent getFile(String id, String tenantDomain, String type) throws StorageSystemException;
 
     boolean isDownloadAllowedForPublicMedia(String id, String type, String tenantDomain) throws
             StorageSystemServerException;
@@ -44,11 +42,9 @@ public interface StorageSystem {
     boolean isMediaManagementAllowedForEndUser(String mediaId, String type, String tenantDomain, String userId) throws
             StorageSystemServerException;
 
-    void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemServerException,
-            StorageSystemClientException;
+    void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemException;
 
-    MediaInformation getMediaInformation(String id, String type, String tenantDomain) throws
-            StorageSystemServerException, StorageSystemClientException;
+    MediaInformation getMediaInformation(String id, String type, String tenantDomain) throws StorageSystemException;
 
     InputStream transform(String id, String type, String tenantDomain, InputStream inputStream)
             throws StorageSystemException;

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StorageSystemFactory.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StorageSystemFactory.java
@@ -22,7 +22,7 @@ package org.wso2.carbon.identity.media.core;
  */
 public abstract class StorageSystemFactory {
 
-    public abstract StorageSystem getInstance();
+    public abstract StorageSystem getStorageSystem();
 
     public abstract String getStorageType();
 }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StorageSystemManager.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StorageSystemManager.java
@@ -19,20 +19,38 @@ package org.wso2.carbon.identity.media.core;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.media.core.exception.StorageSystemClientException;
 import org.wso2.carbon.identity.media.core.exception.StorageSystemException;
+import org.wso2.carbon.identity.media.core.exception.StorageSystemServerException;
 import org.wso2.carbon.identity.media.core.internal.MediaServiceDataHolder;
 import org.wso2.carbon.identity.media.core.model.MediaInformation;
 import org.wso2.carbon.identity.media.core.model.MediaMetadata;
 import org.wso2.carbon.identity.media.core.util.StorageSystemUtil;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
 
-import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.CONFIGURABLE_MAXIMUM_MEDIA_SIZE_IN_BYTES;
+import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.CONFIGURABLE_MEDIA_CONTENT_TYPES;
+import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.CONFIGURABLE_MEDIA_STORE_TYPE;
 
 /**
  * Controller class which invokes specific type of storage type implementation classes using factory pattern.
@@ -48,23 +66,18 @@ public class StorageSystemManager {
      * @param mediaMetadata The metadata object associated with the uploaded file.
      * @param tenantDomain  The tenant domain of the service call.
      * @return unique id related to the uploaded resource.
-     * @throws StorageSystemException Exception related to file upload.
+     * @throws StorageSystemServerException The server exception related to file upload.
      */
     public String addFile(List<InputStream> inputStream, MediaMetadata mediaMetadata, String tenantDomain)
-            throws StorageSystemException {
+            throws StorageSystemServerException {
 
-        if (StringUtils.isNotBlank(tenantDomain)) {
-            StorageSystemFactory storageSystemFactory = getStorageSystemFactory(StorageSystemUtil.getMediaStoreType());
-            if (storageSystemFactory != null) {
-                String uuid = StorageSystemUtil.calculateUUID();
-                return storageSystemFactory.getInstance().addMedia(inputStream, mediaMetadata, uuid, tenantDomain);
-            }
-        }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("StorageSystemFactory object is null. Returning empty string.");
-        }
-        return "";
+        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(getMediaStoreType());
 
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        // id for the uploaded media is calculated by concatenating current date (in yyyyMMdd format) with uuid.
+        String id = LocalDate.now().format(formatter) + "-" + StorageSystemUtil.calculateUUID();
+
+        return storageSystemFactory.getInstance().addMedia(inputStream, mediaMetadata, id, tenantDomain);
     }
 
     /**
@@ -75,21 +88,17 @@ public class StorageSystemManager {
      * @param type         The high level content-type of the resource (if media content-type is image/png then
      *                     type would be image).
      * @return requested file.
-     * @throws StorageSystemException Exception related to retrieving the media.
+     * @throws StorageSystemServerException The server exception related to retrieving the media.
+     * @throws StorageSystemClientException The client exception related to retrieving the media.
      */
-    public DataContent readContent(String id, String tenantDomain, String type) throws StorageSystemException {
+    public DataContent readContent(String id, String tenantDomain, String type) throws StorageSystemServerException,
+            StorageSystemClientException {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(String.format("Download media for tenant domain %s.", tenantDomain));
         }
-        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(StorageSystemUtil.getMediaStoreType());
-        if (storageSystemFactory != null) {
-            return storageSystemFactory.getInstance().getFile(id, tenantDomain, type);
-        }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("StorageSystemFactory object is null hence returning null.");
-        }
-        return null;
+        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(getMediaStoreType());
+        return storageSystemFactory.getInstance().getFile(id, tenantDomain, type);
     }
 
     /**
@@ -100,77 +109,65 @@ public class StorageSystemManager {
      *                     type would be image).
      * @param tenantDomain The tenant domain of the service call.
      * @return true if access to the resource is permitted.
-     * @throws StorageSystemException Exception related to security evaluation during file download.
+     * @throws StorageSystemServerException The server exception related to security evaluation during file download.
      */
     public boolean isDownloadAllowedForPublicMedia(String id, String type, String tenantDomain)
-            throws StorageSystemException {
+            throws StorageSystemServerException {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(String.format("Evaluate security for media of type: %s, unique id: %s and tenant domain %s.",
                     id, type, tenantDomain));
         }
-        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(StorageSystemUtil.getMediaStoreType());
-        if (storageSystemFactory != null) {
-            return storageSystemFactory.getInstance().isDownloadAllowedForPublicMedia(id, type, tenantDomain);
-        }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("StorageSystemFactory object is null hence returning security evaluation result as false.");
-        }
-        return false;
+        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(getMediaStoreType());
+        return storageSystemFactory.getInstance().isDownloadAllowedForPublicMedia(id, type, tenantDomain);
     }
 
     /**
      * Security evaluation for downloading protected resource.
      *
-     * @param id           The unique id related to the requesting resource.
+     * @param mediaId      The unique id related to the requesting resource.
      * @param type         The high level content-type of the resource (if media content-type is image/png then
      *                     type would be image).
      * @param tenantDomain The tenant domain of the service call.
+     * @param username     The username of the user.
      * @return true if access to the resource is permitted.
-     * @throws StorageSystemException Exception related to security evaluation during file download.
+     * @throws StorageSystemServerException The server exception related to security evaluation during file download.
      */
-    public boolean isDownloadAllowedForProtectedMedia(String id, String type, String tenantDomain)
-            throws StorageSystemException {
+    public boolean isDownloadAllowedForProtectedMedia(String mediaId, String type, String tenantDomain, String username)
+            throws StorageSystemServerException {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(String.format("Evaluate download security for media of type: %s, unique id: %s and tenant " +
-                            "domain %s.", id, type, tenantDomain));
+                            "domain %s.", type, mediaId, tenantDomain));
         }
-        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(StorageSystemUtil.getMediaStoreType());
-        if (storageSystemFactory != null) {
-            return storageSystemFactory.getInstance().isDownloadAllowedForProtectedMedia(id, type, tenantDomain);
-        }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("StorageSystemFactory object is null hence returning security evaluation result as false.");
-        }
-        return false;
+        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(getMediaStoreType());
+        String userId = getUserIdFromUserName(username);
+        return storageSystemFactory.getInstance().isDownloadAllowedForProtectedMedia(mediaId, type, tenantDomain,
+                userId);
     }
 
     /**
      * Security evaluation for media management by an end-user.
      *
-     * @param id           The unique id of the media.
-     * @param type         The high level content-type of the media (if media content-type is image/png then
-     *                     type would be image).
+     * @param mediaId      The unique id of the media.
+     * @param type         The high level content-type of the media (if media content-type is image/png then type would
+     *                     be image).
      * @param tenantDomain The tenant domain of the service call.
+     * @param username     The username of the user.
      * @return true if media management is permitted.
-     * @throws StorageSystemException Exception related to security evaluation.
+     * @throws StorageSystemServerException The server exception related to security evaluation.
      */
-    public boolean isMediaManagementAllowedForEndUser(String id, String type, String tenantDomain)
-            throws StorageSystemException {
+    public boolean isMediaManagementAllowedForEndUser(String mediaId, String type, String tenantDomain, String username)
+            throws StorageSystemServerException {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(String.format("Evaluate media management security for media of type: %s, unique id: %s and " +
-                    "tenant domain %s.", id, type, tenantDomain));
+                    "tenant domain %s.", type, mediaId, tenantDomain));
         }
-        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(StorageSystemUtil.getMediaStoreType());
-        if (storageSystemFactory != null) {
-            return storageSystemFactory.getInstance().isMediaManagementAllowedForEndUser(id, type, tenantDomain);
-        }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("StorageSystemFactory object is null hence returning security evaluation result as false.");
-        }
-        return false;
+        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(getMediaStoreType());
+        String userId = getUserIdFromUserName(username);
+        return storageSystemFactory.getInstance().isMediaManagementAllowedForEndUser(mediaId, type, tenantDomain,
+                userId);
     }
 
     /**
@@ -181,20 +178,18 @@ public class StorageSystemManager {
      *                     type would be image).
      * @param tenantDomain The tenant domain of the service call.
      * @return MediaInformation The media information.
-     * @throws StorageSystemException Exception related to retrieving media information.
+     * @throws StorageSystemServerException The server exception related to retrieving media information.
+     * @throws StorageSystemClientException The client exception related to retrieving media information.
      */
     public MediaInformation retrieveMediaInformation(String id, String type, String tenantDomain)
-            throws StorageSystemException {
+            throws StorageSystemServerException, StorageSystemClientException {
 
-        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(StorageSystemUtil.getMediaStoreType());
-        if (storageSystemFactory != null) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(String.format("Retrieve information for media of type: %s, unique id: %s and tenant " +
-                        "domain %s.", id, type, tenantDomain));
-            }
-            return storageSystemFactory.getInstance().getMediaInformation(id, type, tenantDomain);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(String.format("Retrieve information for media of type: %s, unique id: %s and tenant " +
+                    "domain %s.", id, type, tenantDomain));
         }
-        return null;
+        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(getMediaStoreType());
+        return storageSystemFactory.getInstance().getMediaInformation(id, type, tenantDomain);
     }
 
     /**
@@ -204,25 +199,25 @@ public class StorageSystemManager {
      * @param type         The high level content-type of the resource (if media content-type is image/png then
      *                     type would be image).
      * @param tenantDomain The tenant domain of the service call.
-     * @throws StorageSystemException Exception related to file deletion.
+     * @throws StorageSystemServerException The server exception related to file deletion.
+     * @throws StorageSystemClientException The client exception related to file deletion.
      */
-    public void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemException {
+    public void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemServerException,
+            StorageSystemClientException {
 
-        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(StorageSystemUtil.getMediaStoreType());
-        if (storageSystemFactory != null) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(String.format("Delete media of type: %s in tenant domain: %s.", type, tenantDomain));
-            }
-            storageSystemFactory.getInstance().deleteMedia(id, type, tenantDomain);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(String.format("Delete media of type: %s in tenant domain: %s.", type, tenantDomain));
         }
+        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(getMediaStoreType());
+        storageSystemFactory.getInstance().deleteMedia(id, type, tenantDomain);
     }
 
     /**
      * A method to do any transformation to the inputstream.
      *
-     * @param id           unique id related to the requesting resource. (This id consists of uuid, a unique hash
-     *                     value and a timestamp.)
-     * @param type         Type of image (could be i,a, or u) i stands for idp,a stands for app, u stands for user
+     * @param id           The unique id related to the requesting resource.
+     * @param type         The high level content-type of the resource (if media content-type is image/png then
+     *                     type would be image).
      * @param tenantDomain tenantdomain of the service call.
      * @param inputStream  inputstream of the file.
      * @return transformed inputstream.
@@ -231,14 +226,13 @@ public class StorageSystemManager {
     public InputStream transform(String id, String type, String tenantDomain, InputStream inputStream)
             throws StorageSystemException {
 
-        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(StorageSystemUtil.getMediaStoreType());
-        if (storageSystemFactory != null) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(String.format("Delete image for category %s and tenant domain %s.", type, tenantDomain));
-            }
-            return storageSystemFactory.getInstance().transform(id, type, tenantDomain, inputStream);
+        StorageSystemFactory storageSystemFactory = getStorageSystemFactory(getMediaStoreType());
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(String.format("Transform media for category %s and tenant domain %s.", type, tenantDomain));
         }
-        return new ByteArrayInputStream(new byte[0]);
+        return storageSystemFactory.getInstance().transform(id, type, tenantDomain, inputStream);
+
     }
 
     /**
@@ -253,16 +247,38 @@ public class StorageSystemManager {
     public void validateFileUploadMediaTypes(String mediaTypePathParam, String contentSubType)
             throws StorageSystemClientException {
 
-        HashMap<String, List<String>> allowedContentTypes = StorageSystemUtil.getContentTypes();
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Started content type validation for media to be uploaded.");
+        }
+
+        String environmentVariableForAllowedContentTypes = System.getenv(CONFIGURABLE_MEDIA_CONTENT_TYPES);
+        HashMap<String, List<String>> allowedContentTypes = new HashMap<>();
+        if (StringUtils.isNotBlank(environmentVariableForAllowedContentTypes)) {
+            String[] contentTypes = environmentVariableForAllowedContentTypes.split(",");
+            for (String contentType : contentTypes) {
+                String environmentVariableForAllowedContentSubTypes =
+                        System.getenv(String.format("MEDIA_%s_CONTENT_SUB_TYPES",
+                                contentType.toUpperCase(Locale.ENGLISH)));
+                if (StringUtils.isNotBlank(environmentVariableForAllowedContentSubTypes)) {
+                    allowedContentTypes.put(contentType, Arrays.asList(environmentVariableForAllowedContentSubTypes
+                            .split(",")));
+                } else {
+                    allowedContentTypes.put(contentType, null);
+                }
+            }
+        } else {
+            allowedContentTypes = StorageSystemUtil.getContentTypes();
+        }
+
         if (MapUtils.isEmpty(allowedContentTypes) || !allowedContentTypes.keySet().contains(mediaTypePathParam)) {
             throw new StorageSystemClientException(String.format("Uploading media of content-type: %s/%s is not " +
-                            "allowed.", mediaTypePathParam, contentSubType));
+                    "allowed.", mediaTypePathParam, contentSubType));
         }
 
         List<String> allowedContentSubTypes = allowedContentTypes.get(mediaTypePathParam);
         if (CollectionUtils.isEmpty(allowedContentSubTypes) || !allowedContentSubTypes.contains(contentSubType)) {
             throw new StorageSystemClientException(String.format("Uploading media of content-type: %s/%s is not " +
-                            "allowed.", mediaTypePathParam, contentSubType));
+                    "allowed.", mediaTypePathParam, contentSubType));
         }
     }
 
@@ -274,17 +290,111 @@ public class StorageSystemManager {
      */
     public void validateMediaTypePathParam(String mediaTypePathParam) throws StorageSystemClientException {
 
-        HashMap<String, List<String>> allowedContentTypes = StorageSystemUtil.getContentTypes();
-        if (MapUtils.isEmpty(allowedContentTypes) || !allowedContentTypes.keySet().contains(mediaTypePathParam)) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Started validating if the media content type path parameter in the request is a " +
+                    "supported content type.");
+        }
+
+        String environmentVariableForAllowedContentTypes = System.getenv(CONFIGURABLE_MEDIA_CONTENT_TYPES);
+        Set<String> allowedContentTypes;
+        if (StringUtils.isNotBlank(environmentVariableForAllowedContentTypes)) {
+            String[] contentTypes = environmentVariableForAllowedContentTypes.split(",");
+            allowedContentTypes = new HashSet<>(Arrays.asList(contentTypes));
+
+        } else {
+            allowedContentTypes = StorageSystemUtil.getContentTypes().keySet();
+        }
+
+        if (CollectionUtils.isEmpty(allowedContentTypes) || !allowedContentTypes.contains(mediaTypePathParam)) {
             throw new StorageSystemClientException(String.format("Unsupported file content type: %s available as a " +
                     "path parameter in the request.", mediaTypePathParam));
         }
     }
 
-    private StorageSystemFactory getStorageSystemFactory(String storageType) {
+    /**
+     * Retrieve the username of the user who is making the request to the media service.
+     *
+     * @param username The username.
+     * @return user id.
+     * @throws StorageSystemServerException The server exception related retrieving user ID from username.
+     */
+    public String getUserIdFromUserName(String username) throws StorageSystemServerException {
 
-        return MediaServiceDataHolder.getInstance().getStorageSystemFactories().get(storageType);
+        try {
+            RealmService realmService = MediaServiceDataHolder.getInstance().getRealmService();
+            int tenantID = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+            UserRealm userRealm = realmService.getTenantUserRealm(tenantID);
+            if (userRealm != null) {
+                UserStoreManager userStoreManager = (UserStoreManager) userRealm.getUserStoreManager();
+                String userIdFromUserName = ((AbstractUserStoreManager) userStoreManager)
+                        .getUserIDFromUserName(username);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(String.format("The user id for the username: %s retrieved successfully.", username));
+                }
+                return userIdFromUserName;
+            }
+        } catch (UserStoreException e) {
+            throw new StorageSystemServerException("Error occurred while retrieving the userstore manager to resolve" +
+                    " id for the user: " + username, e);
+        }
+        return null;
+    }
 
+    /**
+     * Validates if the file size of the media to be uploaded doesn't exceed the maximum allowed file size.
+     *
+     * @param inputStream The media as an input.
+     * @throws StorageSystemServerException The server exception related to validating media size.
+     * @throws StorageSystemClientException The client exception related to validating media size.
+     */
+    public void validateMediaSize(InputStream inputStream) throws StorageSystemServerException,
+            StorageSystemClientException {
+
+        String environmentVariableForMediaSize = System.getenv(CONFIGURABLE_MAXIMUM_MEDIA_SIZE_IN_BYTES);
+        int allowedMaximumMediaSize;
+        if (StringUtils.isNotBlank(environmentVariableForMediaSize)) {
+            allowedMaximumMediaSize = Integer.parseInt(environmentVariableForMediaSize);
+        } else {
+            allowedMaximumMediaSize = StorageSystemUtil.getMediaMaximumSize();
+        }
+
+        try {
+            byte[] mediaByteArray = IOUtils.toByteArray(inputStream);
+            if (mediaByteArray.length > allowedMaximumMediaSize) {
+                throw new StorageSystemClientException(String.format("The uploaded media size: %skb exceeds the " +
+                                "maximum allowed file size: %skb", mediaByteArray.length / 1000.0,
+                        allowedMaximumMediaSize / 1000.0));
+            }
+            inputStream.reset();
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(String.format("The file size: %skb of the media to be uploaded doesn't exceed the " +
+                                "maximum allowed file size: %skb. Hence proceeding with the upload.",
+                        mediaByteArray.length / 1000.0, allowedMaximumMediaSize / 1000.0));
+            }
+        } catch (IOException e) {
+            throw new StorageSystemServerException("Error occurred while calculating media size.", e);
+        }
+    }
+
+    private String getMediaStoreType() {
+
+        String environmentVariableForMediaStoreType = System.getenv(CONFIGURABLE_MEDIA_STORE_TYPE);
+        if (StringUtils.isNotBlank(environmentVariableForMediaStoreType)) {
+            return environmentVariableForMediaStoreType;
+        } else {
+            return StorageSystemUtil.getMediaStoreType();
+        }
+    }
+
+    private StorageSystemFactory getStorageSystemFactory(String storageType) throws StorageSystemServerException {
+
+        StorageSystemFactory storageSystemFactory =
+                MediaServiceDataHolder.getInstance().getStorageSystemFactories().get(storageType);
+        if (storageSystemFactory == null) {
+            throw new StorageSystemServerException(String.format("Unable to obtain StorageSystemFactory for " +
+                    "configured media store type: %s", storageType));
+        }
+        return storageSystemFactory;
     }
 
 }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StorageSystemManager.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StorageSystemManager.java
@@ -88,11 +88,9 @@ public class StorageSystemManager {
      * @param type         The high level content-type of the resource (if media content-type is image/png then
      *                     type would be image).
      * @return requested file.
-     * @throws StorageSystemServerException The server exception related to retrieving the media.
-     * @throws StorageSystemClientException The client exception related to retrieving the media.
+     * @throws StorageSystemException Exception related to retrieving the media.
      */
-    public DataContent readContent(String id, String tenantDomain, String type) throws StorageSystemServerException,
-            StorageSystemClientException {
+    public DataContent readContent(String id, String tenantDomain, String type) throws StorageSystemException {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(String.format("Download media for tenant domain %s.", tenantDomain));
@@ -178,11 +176,10 @@ public class StorageSystemManager {
      *                     type would be image).
      * @param tenantDomain The tenant domain of the service call.
      * @return MediaInformation The media information.
-     * @throws StorageSystemServerException The server exception related to retrieving media information.
-     * @throws StorageSystemClientException The client exception related to retrieving media information.
+     * @throws StorageSystemException Exception related to retrieving media information.
      */
     public MediaInformation retrieveMediaInformation(String id, String type, String tenantDomain)
-            throws StorageSystemServerException, StorageSystemClientException {
+            throws StorageSystemException {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(String.format("Retrieve information for media of type: %s, unique id: %s and tenant " +
@@ -199,11 +196,9 @@ public class StorageSystemManager {
      * @param type         The high level content-type of the resource (if media content-type is image/png then
      *                     type would be image).
      * @param tenantDomain The tenant domain of the service call.
-     * @throws StorageSystemServerException The server exception related to file deletion.
-     * @throws StorageSystemClientException The client exception related to file deletion.
+     * @throws StorageSystemException Exception related to file deletion.
      */
-    public void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemServerException,
-            StorageSystemClientException {
+    public void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemException {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(String.format("Delete media of type: %s in tenant domain: %s.", type, tenantDomain));
@@ -251,10 +246,10 @@ public class StorageSystemManager {
             LOGGER.debug("Started content type validation for media to be uploaded.");
         }
 
-        String environmentVariableForAllowedContentTypes = System.getenv(CONFIGURABLE_MEDIA_CONTENT_TYPES);
+        String envForAllowedContentTypes = System.getenv(CONFIGURABLE_MEDIA_CONTENT_TYPES);
         HashMap<String, List<String>> allowedContentTypes = new HashMap<>();
-        if (StringUtils.isNotBlank(environmentVariableForAllowedContentTypes)) {
-            String[] contentTypes = environmentVariableForAllowedContentTypes.split(",");
+        if (StringUtils.isNotBlank(envForAllowedContentTypes)) {
+            String[] contentTypes = envForAllowedContentTypes.split(",");
             for (String contentType : contentTypes) {
                 String environmentVariableForAllowedContentSubTypes =
                         System.getenv(String.format("MEDIA_%s_CONTENT_SUB_TYPES",
@@ -295,10 +290,10 @@ public class StorageSystemManager {
                     "supported content type.");
         }
 
-        String environmentVariableForAllowedContentTypes = System.getenv(CONFIGURABLE_MEDIA_CONTENT_TYPES);
+        String envForAllowedContentTypes = System.getenv(CONFIGURABLE_MEDIA_CONTENT_TYPES);
         Set<String> allowedContentTypes;
-        if (StringUtils.isNotBlank(environmentVariableForAllowedContentTypes)) {
-            String[] contentTypes = environmentVariableForAllowedContentTypes.split(",");
+        if (StringUtils.isNotBlank(envForAllowedContentTypes)) {
+            String[] contentTypes = envForAllowedContentTypes.split(",");
             allowedContentTypes = new HashSet<>(Arrays.asList(contentTypes));
 
         } else {
@@ -344,16 +339,14 @@ public class StorageSystemManager {
      * Validates if the file size of the media to be uploaded doesn't exceed the maximum allowed file size.
      *
      * @param inputStream The media as an input.
-     * @throws StorageSystemServerException The server exception related to validating media size.
-     * @throws StorageSystemClientException The client exception related to validating media size.
+     * @throws StorageSystemException Exception related to validating media size.
      */
-    public void validateMediaSize(InputStream inputStream) throws StorageSystemServerException,
-            StorageSystemClientException {
+    public void validateMediaSize(InputStream inputStream) throws StorageSystemException {
 
-        String environmentVariableForMediaSize = System.getenv(CONFIGURABLE_MAXIMUM_MEDIA_SIZE_IN_BYTES);
+        String envForMediaSize = System.getenv(CONFIGURABLE_MAXIMUM_MEDIA_SIZE_IN_BYTES);
         int allowedMaximumMediaSize;
-        if (StringUtils.isNotBlank(environmentVariableForMediaSize)) {
-            allowedMaximumMediaSize = Integer.parseInt(environmentVariableForMediaSize);
+        if (StringUtils.isNotBlank(envForMediaSize)) {
+            allowedMaximumMediaSize = Integer.parseInt(envForMediaSize);
         } else {
             allowedMaximumMediaSize = StorageSystemUtil.getMediaMaximumSize();
         }
@@ -378,9 +371,9 @@ public class StorageSystemManager {
 
     private String getMediaStoreType() {
 
-        String environmentVariableForMediaStoreType = System.getenv(CONFIGURABLE_MEDIA_STORE_TYPE);
-        if (StringUtils.isNotBlank(environmentVariableForMediaStoreType)) {
-            return environmentVariableForMediaStoreType;
+        String envForMediaStoreType = System.getenv(CONFIGURABLE_MEDIA_STORE_TYPE);
+        if (StringUtils.isNotBlank(envForMediaStoreType)) {
+            return envForMediaStoreType;
         } else {
             return StorageSystemUtil.getMediaStoreType();
         }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StreamContent.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StreamContent.java
@@ -35,4 +35,6 @@ public interface StreamContent extends DataContent {
     InputStream getInputStream();
 
     String getResponseContentType();
+
+    String getETag();
 }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StreamContentImpl.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/StreamContentImpl.java
@@ -27,16 +27,18 @@ public class StreamContentImpl implements StreamContent {
 
     private InputStream inputStream;
     private String responseContentType;
+    private String etag;
 
     public StreamContentImpl(InputStream inputStream) {
 
         this.inputStream = inputStream;
     }
 
-    public StreamContentImpl(InputStream inputStream, String responseContentType) {
+    public StreamContentImpl(InputStream inputStream, String responseContentType, String etag) {
 
         this.inputStream = inputStream;
         this.responseContentType = responseContentType;
+        this.etag = etag;
     }
 
     @Override
@@ -49,5 +51,11 @@ public class StreamContentImpl implements StreamContent {
     public String getResponseContentType() {
 
         return responseContentType;
+    }
+
+    @Override
+    public String getETag() {
+
+        return etag;
     }
 }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/file/FileBasedStorageSystemFactory.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/file/FileBasedStorageSystemFactory.java
@@ -26,7 +26,7 @@ public class FileBasedStorageSystemFactory extends StorageSystemFactory {
     private static final String FILE = "org.wso2.carbon.identity.media.file.FileBasedStorageSystemImpl";
 
     @Override
-    public StorageSystem getInstance() {
+    public StorageSystem getStorageSystem() {
 
         StorageSystem fileBasedStorageSystemImpl = new FileBasedStorageSystemImpl();
         return fileBasedStorageSystemImpl;

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/file/FileBasedStorageSystemImpl.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/file/FileBasedStorageSystemImpl.java
@@ -373,7 +373,7 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
             JSONParser jsonParser = new JSONParser();
             Object metadata = jsonParser.parse(reader);
             String resourceOwner = (String) ((JSONObject) metadata).get(MEDIA_RESOURCE_OWNER_ID);
-            return StringUtils.isNotBlank(resourceOwner) && resourceOwner.equals(userId);
+            return StringUtils.equals(resourceOwner, userId);
         }
     }
 
@@ -520,8 +520,8 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
         if (configurableRootFolder != null) {
             fileStorageLocation = configurableRootFolder.resolve(Paths.get(PRE_CREATED_MEDIA_FOLDER));
 
-            // The system expects a pre-created folder called 'media' to exist in the configured media mount base
-            // directory.
+            /* The system expects a pre-created folder called 'media' to exist in the configured media mount base
+            directory. */
             if (Files.notExists(fileStorageLocation)) {
                 throw new StorageSystemServerException(String.format("A pre-created \"media\" folder within the " +
                         "configured media mount base directory %s is expected.", configurableRootFolder));

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/file/FileBasedStorageSystemImpl.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/file/FileBasedStorageSystemImpl.java
@@ -92,8 +92,7 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
     }
 
     @Override
-    public DataContent getFile(String id, String tenantDomain, String type) throws StorageSystemServerException,
-            StorageSystemClientException {
+    public DataContent getFile(String id, String tenantDomain, String type) throws StorageSystemException {
 
         FileContentImpl fileContent = null;
         try {
@@ -183,8 +182,7 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
     }
 
     @Override
-    public void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemServerException,
-            StorageSystemClientException {
+    public void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemException {
 
         try {
             deleteFile(id, type, tenantDomain);

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/file/FileBasedStorageSystemImpl.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/file/FileBasedStorageSystemImpl.java
@@ -16,14 +16,12 @@
 package org.wso2.carbon.identity.media.core.file;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.media.core.DataContent;
 import org.wso2.carbon.identity.media.core.FileContentImpl;
@@ -35,6 +33,7 @@ import org.wso2.carbon.identity.media.core.model.FileSecurity;
 import org.wso2.carbon.identity.media.core.model.MediaFileDownloadData;
 import org.wso2.carbon.identity.media.core.model.MediaInformation;
 import org.wso2.carbon.identity.media.core.model.MediaMetadata;
+import org.wso2.carbon.identity.media.core.util.StorageSystemUtil;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -55,17 +54,17 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.CONFIGURABLE_UPLOAD_LOCATION;
+import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.CONFIGURABLE_MEDIA_MOUNT_LOCATION;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_CONTENT_TYPE;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_NAME;
-import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_RESOURCE_OWNER;
+import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_RESOURCE_OWNER_ID;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_SECURITY;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_SECURITY_ALLOWED_ALL;
-import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_SECURITY_ALLOWED_USERS;
-import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_STORE;
+import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_SECURITY_ALLOWED_USER_IDS;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_TAG;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.METADATA_FILE_EXTENSION;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.METADATA_FILE_SUFFIX;
+import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.PRE_CREATED_MEDIA_FOLDER;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.PROTECTED_DOWNLOAD_ACCESS;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.PUBLIC_DOWNLOAD_ACCESS;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.SYSTEM_PROPERTY_CARBON_HOME;
@@ -79,7 +78,7 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
 
     @Override
     public String addMedia(List<InputStream> inputStreams, MediaMetadata mediaMetadata, String uuid,
-                           String tenantDomain) throws StorageSystemException {
+                           String tenantDomain) throws StorageSystemServerException {
 
         try {
             if (LOGGER.isDebugEnabled()) {
@@ -90,11 +89,11 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
         } catch (IOException e) {
             throw new StorageSystemServerException("Error while uploading media to file system.", e);
         }
-
     }
 
     @Override
-    public DataContent getFile(String id, String tenantDomain, String type) throws StorageSystemException {
+    public DataContent getFile(String id, String tenantDomain, String type) throws StorageSystemServerException,
+            StorageSystemClientException {
 
         FileContentImpl fileContent = null;
         try {
@@ -102,6 +101,10 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
             if (mediaFileDownloadData != null && mediaFileDownloadData.getMediaFile() != null) {
                 fileContent = new FileContentImpl(mediaFileDownloadData.getMediaFile(),
                         mediaFileDownloadData.getResponseContentType());
+            }
+            if (fileContent == null) {
+                throw new StorageSystemClientException(String.format("Requested media of type: %s with id: %s in" +
+                        " tenant domain: %s is not exiting in the storage system.", type, id, tenantDomain));
             }
             return fileContent;
         } catch (IOException e) {
@@ -115,7 +118,7 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
 
     @Override
     public boolean isDownloadAllowedForPublicMedia(String id, String type, String tenantDomain) throws
-            StorageSystemException {
+            StorageSystemServerException {
 
         File file;
         try {
@@ -136,51 +139,52 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
     }
 
     @Override
-    public boolean isDownloadAllowedForProtectedMedia(String id, String type, String tenantDomain) throws
-            StorageSystemException {
+    public boolean isDownloadAllowedForProtectedMedia(String mediaId, String type, String tenantDomain, String userId)
+            throws StorageSystemServerException {
 
         File file;
         try {
-            file = getMediaMetadataFile(id, type, tenantDomain);
+            file = getMediaMetadataFile(mediaId, type, tenantDomain);
             if (file != null && file.exists()) {
-                return isFileAccessAllowed(file);
+                return isFileAccessAllowed(file, userId);
             }
             return false;
         } catch (IOException e) {
             String errorMsg = String.format("Error while retrieving metadata for stored file with id: %s and of type " +
-                    "%s in tenant domain: %s", id, type, tenantDomain);
+                    "%s in tenant domain: %s", mediaId, type, tenantDomain);
             throw new StorageSystemServerException(errorMsg, e);
         } catch (ParseException e) {
             String errorMsg = String.format("Unable to parse metadata in JSON format for stored file with id : %s " +
-                    "and of type %s in tenant domain: %s", id, type, tenantDomain);
+                    "and of type %s in tenant domain: %s", mediaId, type, tenantDomain);
             throw new StorageSystemServerException(errorMsg, e);
         }
     }
 
     @Override
-    public boolean isMediaManagementAllowedForEndUser(String id, String type, String tenantDomain) throws
-            StorageSystemException {
+    public boolean isMediaManagementAllowedForEndUser(String mediaId, String type, String tenantDomain, String userId)
+            throws StorageSystemServerException {
 
         File file;
         try {
-            file = getMediaMetadataFile(id, type, tenantDomain);
+            file = getMediaMetadataFile(mediaId, type, tenantDomain);
             if (file != null && file.exists()) {
-                return isMediaManagementAllowed(file);
+                return isMediaManagementAllowed(file, userId);
             }
             return false;
         } catch (IOException e) {
             String errorMsg = String.format("Error while retrieving metadata for stored file with id: %s and of type " +
-                    "%s in tenant domain: %s", id, type, tenantDomain);
+                    "%s in tenant domain: %s", mediaId, type, tenantDomain);
             throw new StorageSystemServerException(errorMsg, e);
         } catch (ParseException e) {
             String errorMsg = String.format("Unable to parse metadata in JSON format for stored file with id : %s " +
-                    "and of type %s in tenant domain: %s", id, type, tenantDomain);
+                    "and of type %s in tenant domain: %s", mediaId, type, tenantDomain);
             throw new StorageSystemServerException(errorMsg, e);
         }
     }
 
     @Override
-    public void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemException {
+    public void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemServerException,
+            StorageSystemClientException {
 
         try {
             deleteFile(id, type, tenantDomain);
@@ -192,15 +196,17 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
 
     @Override
     public MediaInformation getMediaInformation(String id, String type, String tenantDomain) throws
-            StorageSystemException {
+            StorageSystemServerException, StorageSystemClientException {
 
         File file;
         try {
             file = getMediaMetadataFile(id, type, tenantDomain);
-            if (file != null && file.exists()) {
-                return getMediaInformation(file, type, id);
+            if (file == null || !file.exists()) {
+                throw new StorageSystemClientException(String.format("Media information retrieval request can't be" +
+                        " performed as media with id: %s of type: %s in tenant domain: %s is not existing.", id, type,
+                        tenantDomain));
             }
-            return null;
+            return getMediaInformation(file, type, id);
         } catch (IOException e) {
             String errorMsg = String.format("Error while retrieving metadata for stored file with id: %s and of type " +
                     "%s in tenant domain: %s", id, type, tenantDomain);
@@ -219,23 +225,20 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
     }
 
     private String uploadMediaUsingChannels(List<InputStream> fileInputStreams, MediaMetadata mediaMetadata,
-                                            String uuid, String tenantDomain) throws IOException {
+                                            String uuid, String tenantDomain) throws IOException,
+            StorageSystemServerException {
 
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
         String fileContentType = mediaMetadata.getFileContentType();
         String fileType = fileContentType.split("/")[0];
         String fileTag = mediaMetadata.getFileTag();
         String fileName = mediaMetadata.getFileName();
-        String resourceOwner = mediaMetadata.getResourceOwner();
+        String resourceOwner = mediaMetadata.getResourceOwnerId();
         FileSecurity fileSecurity = mediaMetadata.getFileSecurity();
 
         Path mediaStoragePath = createStorageDirectory(fileType, tenantId, uuid);
 
         if (mediaStoragePath != null) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(String.format("Uploading media file to directory %s, for tenant id %d",
-                        mediaStoragePath.toString(), tenantId));
-            }
             Path targetLocation = mediaStoragePath.resolve(uuid);
             File file = targetLocation.toFile();
             // Currently, only single file upload is allowed.
@@ -244,9 +247,8 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
                  ReadableByteChannel readableByteChannel = Channels.newChannel(fileInputStreams.get(0))) {
                 fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
                 if (LOGGER.isDebugEnabled()) {
-                    byte[] imageByteCount = IOUtils.toByteArray(fileInputStreams.get(0));
-                    LOGGER.debug(String.format("Writing media data of size %d to a file named %s at location %s.",
-                            imageByteCount.length, uuid, targetLocation.toString()));
+                    LOGGER.debug(String.format("Uploaded media file: %s to directory: %s, for tenant id: %d and type:" +
+                                    " %s successfully.", uuid, mediaStoragePath.toString(), tenantId, fileType));
                 }
             }
 
@@ -259,13 +261,15 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
         return "";
     }
 
-    private Path createStorageDirectory(String fileType, int tenantId, String uuid) throws IOException {
+    private Path createStorageDirectory(String fileType, int tenantId, String uuid) throws IOException,
+            StorageSystemServerException {
 
-        Path fileStorageLocation = getFileStorageLocation(fileType);
+        Path fileStorageLocation = getMediaFolderPreCreatedLocation();
         Path mediaPath = null;
 
         if (fileStorageLocation != null) {
-            mediaPath = Files.createDirectories(fileStorageLocation.resolve(String.valueOf(tenantId)));
+            mediaPath = Files.createDirectories(fileStorageLocation.resolve(Paths.get(fileType,
+                    String.valueOf(tenantId))));
         }
 
         return createUniqueDirectoryStructure(mediaPath, uuid);
@@ -277,8 +281,8 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
         Path uniquePath;
         if (path != null) {
             uniquePath = path;
-            for (int i = 1; i <= uuidSplit.length; i++) {
-                uniquePath = uniquePath.resolve(uuidSplit[uuidSplit.length - i]);
+            for (String pathComponent : uuidSplit) {
+                uniquePath = uniquePath.resolve(pathComponent);
             }
             return Files.createDirectories(uniquePath);
         }
@@ -343,7 +347,7 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
         return false;
     }
 
-    private boolean isFileAccessAllowed(File file) throws IOException, ParseException {
+    private boolean isFileAccessAllowed(File file, String userId) throws IOException, ParseException {
 
         try (InputStreamReader reader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)) {
             JSONParser jsonParser = new JSONParser();
@@ -353,31 +357,30 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
                 if ((Boolean) fileSecurity.get(MEDIA_SECURITY_ALLOWED_ALL)) {
                     return true;
                 }
-                return isUserAllowed(fileSecurity);
+                return isUserAllowed(fileSecurity, userId);
             }
             return false;
         }
     }
 
-    private boolean isMediaManagementAllowed(File file) throws IOException, ParseException {
+    private boolean isMediaManagementAllowed(File file, String userId) throws IOException, ParseException {
 
         try (InputStreamReader reader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)) {
             JSONParser jsonParser = new JSONParser();
             Object metadata = jsonParser.parse(reader);
-            String resourceOwner = (String) ((JSONObject) metadata).get(MEDIA_RESOURCE_OWNER);
-            return StringUtils.isNotBlank(resourceOwner) &&
-                    resourceOwner.equals(PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername());
+            String resourceOwner = (String) ((JSONObject) metadata).get(MEDIA_RESOURCE_OWNER_ID);
+            return StringUtils.isNotBlank(resourceOwner) && resourceOwner.equals(userId);
         }
     }
 
-    private boolean isUserAllowed(HashMap fileSecurity) {
+    private boolean isUserAllowed(HashMap fileSecurity, String userId) {
 
-        ArrayList allowedUsers = (ArrayList) fileSecurity.get(MEDIA_SECURITY_ALLOWED_USERS);
-        if (allowedUsers != null) {
-            for (Object allowedUser : allowedUsers) {
-                if (allowedUser instanceof String) {
-                    String user = (String) allowedUser;
-                    if (user.equals(PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername())) {
+        ArrayList allowedUserIds = (ArrayList) fileSecurity.get(MEDIA_SECURITY_ALLOWED_USER_IDS);
+        if (allowedUserIds != null) {
+            for (Object allowedUserId : allowedUserIds) {
+                if (allowedUserId instanceof String) {
+                    String user = (String) allowedUserId;
+                    if (user.equals(userId)) {
                         return true;
                     }
                 }
@@ -429,7 +432,7 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
             metadata.put(MEDIA_TAG, fileTag);
         }
         if (StringUtils.isNotBlank(resourceOwner)) {
-            metadata.put(MEDIA_RESOURCE_OWNER, resourceOwner);
+            metadata.put(MEDIA_RESOURCE_OWNER_ID, resourceOwner);
         }
         storeFileSecurityMetadata(fileSecurity, metadata);
 
@@ -447,9 +450,9 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
         fileSecurityJSON.put(MEDIA_SECURITY_ALLOWED_ALL, allowedAll);
 
         if (!allowedAll) {
-            List<String> allowedUsers = fileSecurity.getAllowedUsers();
-            if (CollectionUtils.isNotEmpty(allowedUsers)) {
-                fileSecurityJSON.put(MEDIA_SECURITY_ALLOWED_USERS, allowedUsers);
+            List<String> allowedUserIds = fileSecurity.getAllowedUserIds();
+            if (CollectionUtils.isNotEmpty(allowedUserIds)) {
+                fileSecurityJSON.put(MEDIA_SECURITY_ALLOWED_USER_IDS, allowedUserIds);
             }
         }
         metadata.put(MEDIA_SECURITY, fileSecurityJSON);
@@ -497,20 +500,45 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
     private Path getFileStorageLocation(String fileType) {
 
         Path fileStorageLocation = null;
+        Path configurableRootFolder = getMediaMountBaseDirectory();
+
+        if (configurableRootFolder != null) {
+            fileStorageLocation = configurableRootFolder.resolve(Paths.get(PRE_CREATED_MEDIA_FOLDER, fileType));
+        }
+        return fileStorageLocation;
+    }
+
+    private Path getMediaFolderPreCreatedLocation() throws StorageSystemServerException {
+
+        Path fileStorageLocation = null;
+        Path configurableRootFolder = getMediaMountBaseDirectory();
+
+        if (configurableRootFolder != null) {
+            fileStorageLocation = configurableRootFolder.resolve(Paths.get(PRE_CREATED_MEDIA_FOLDER));
+
+            // The system expects a pre-created folder called 'media' to exist in the configured media mount base
+            // directory.
+            if (Files.notExists(fileStorageLocation)) {
+                throw new StorageSystemServerException(String.format("A pre-created \"media\" folder within the " +
+                        "configured media mount base directory %s is expected.", configurableRootFolder));
+            }
+        }
+        return fileStorageLocation;
+    }
+
+    private Path getMediaMountBaseDirectory() {
+
         Path configurableRootFolder = null;
-        String systemPropertyForRootFolder = System.getProperty(CONFIGURABLE_UPLOAD_LOCATION);
-        if (systemPropertyForRootFolder != null) {
-            configurableRootFolder = Paths.get(systemPropertyForRootFolder);
+        String environmentVariableForRootFolder = System.getenv(CONFIGURABLE_MEDIA_MOUNT_LOCATION);
+        if (StringUtils.isNotBlank(environmentVariableForRootFolder)) {
+            configurableRootFolder = Paths.get(environmentVariableForRootFolder);
         }
 
         if (configurableRootFolder == null) {
-            configurableRootFolder = Paths.get(System.getProperty(SYSTEM_PROPERTY_CARBON_HOME));
+            configurableRootFolder = Paths.get(System.getProperty(SYSTEM_PROPERTY_CARBON_HOME),
+                    StorageSystemUtil.getMediaMountLocation());
         }
-
-        if (configurableRootFolder != null) {
-            fileStorageLocation = configurableRootFolder.resolve(Paths.get(MEDIA_STORE + fileType));
-        }
-        return fileStorageLocation;
+        return configurableRootFolder;
     }
 
     private Path getUniqueDirectoryStructure(Path path, String uuid) {
@@ -519,8 +547,8 @@ public class FileBasedStorageSystemImpl implements StorageSystem {
         Path uniquePath;
         if (path != null) {
             uniquePath = path;
-            for (int i = 1; i <= uuidSplit.length; i++) {
-                uniquePath = uniquePath.resolve(uuidSplit[uuidSplit.length - i]);
+            for (String pathComponent : uuidSplit) {
+                uniquePath = uniquePath.resolve(pathComponent);
             }
             if (Files.exists(uniquePath)) {
                 return uniquePath;

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/jdbc/DatabaseBasedStorageSystemFactory.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/jdbc/DatabaseBasedStorageSystemFactory.java
@@ -26,7 +26,7 @@ public class DatabaseBasedStorageSystemFactory extends StorageSystemFactory {
     private static final String JDBC = "org.wso2.carbon.identity.media.jdbc.DatabaseBasedStorageSystemImpl";
 
     @Override
-    public StorageSystem getInstance() {
+    public StorageSystem getStorageSystem() {
 
         StorageSystem dbBasedStorageSystem = new DatabaseBasedStorageSystemImpl();
         return dbBasedStorageSystem;

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/jdbc/DatabaseBasedStorageSystemImpl.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/jdbc/DatabaseBasedStorageSystemImpl.java
@@ -17,7 +17,6 @@ package org.wso2.carbon.identity.media.core.jdbc;
 
 import org.wso2.carbon.identity.media.core.DataContent;
 import org.wso2.carbon.identity.media.core.StorageSystem;
-import org.wso2.carbon.identity.media.core.exception.StorageSystemClientException;
 import org.wso2.carbon.identity.media.core.exception.StorageSystemException;
 import org.wso2.carbon.identity.media.core.exception.StorageSystemServerException;
 import org.wso2.carbon.identity.media.core.model.MediaInformation;
@@ -39,8 +38,7 @@ public class DatabaseBasedStorageSystemImpl implements StorageSystem {
     }
 
     @Override
-    public DataContent getFile(String id, String tenantDomain, String type) throws StorageSystemServerException,
-            StorageSystemClientException {
+    public DataContent getFile(String id, String tenantDomain, String type) throws StorageSystemException {
 
         throw new UnsupportedOperationException("Database based get file operation not supported.");
     }
@@ -67,15 +65,14 @@ public class DatabaseBasedStorageSystemImpl implements StorageSystem {
     }
 
     @Override
-    public void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemServerException,
-            StorageSystemClientException {
+    public void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemException {
 
         throw new UnsupportedOperationException("Database based delete file operation not supported.");
     }
 
     @Override
     public MediaInformation getMediaInformation(String id, String type, String tenantDomain) throws
-            StorageSystemServerException, StorageSystemClientException {
+            StorageSystemException {
 
         throw new UnsupportedOperationException("Database based media information retrieval not supported.");
     }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/jdbc/DatabaseBasedStorageSystemImpl.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/jdbc/DatabaseBasedStorageSystemImpl.java
@@ -17,7 +17,9 @@ package org.wso2.carbon.identity.media.core.jdbc;
 
 import org.wso2.carbon.identity.media.core.DataContent;
 import org.wso2.carbon.identity.media.core.StorageSystem;
+import org.wso2.carbon.identity.media.core.exception.StorageSystemClientException;
 import org.wso2.carbon.identity.media.core.exception.StorageSystemException;
+import org.wso2.carbon.identity.media.core.exception.StorageSystemServerException;
 import org.wso2.carbon.identity.media.core.model.MediaInformation;
 import org.wso2.carbon.identity.media.core.model.MediaMetadata;
 
@@ -31,47 +33,49 @@ public class DatabaseBasedStorageSystemImpl implements StorageSystem {
 
     @Override
     public String addMedia(List<InputStream> inputStreams, MediaMetadata mediaMetadata, String uuid,
-                           String tenantDomain) throws StorageSystemException {
+                           String tenantDomain) throws StorageSystemServerException {
 
         throw new UnsupportedOperationException("Database based add file operation not supported.");
     }
 
     @Override
-    public DataContent getFile(String id, String tenantDomain, String type) throws StorageSystemException {
+    public DataContent getFile(String id, String tenantDomain, String type) throws StorageSystemServerException,
+            StorageSystemClientException {
 
         throw new UnsupportedOperationException("Database based get file operation not supported.");
     }
 
     @Override
     public boolean isDownloadAllowedForPublicMedia(String id, String type, String tenantDomain) throws
-            StorageSystemException {
+            StorageSystemServerException {
 
         throw new UnsupportedOperationException("Database based security evaluation not supported.");
     }
 
     @Override
-    public boolean isDownloadAllowedForProtectedMedia(String id, String type, String tenantDomain) throws
-            StorageSystemException {
+    public boolean isDownloadAllowedForProtectedMedia(String mediaId, String type, String tenantDomain, String userId)
+            throws StorageSystemServerException {
 
         throw new UnsupportedOperationException("Database based security evaluation not supported.");
     }
 
     @Override
-    public boolean isMediaManagementAllowedForEndUser(String id, String type, String tenantDomain) throws
-            StorageSystemException {
+    public boolean isMediaManagementAllowedForEndUser(String mediaId, String type, String tenantDomain, String userId)
+            throws StorageSystemServerException {
 
         throw new UnsupportedOperationException("Database based security evaluation not supported.");
     }
 
     @Override
-    public void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemException {
+    public void deleteMedia(String id, String type, String tenantDomain) throws StorageSystemServerException,
+            StorageSystemClientException {
 
         throw new UnsupportedOperationException("Database based delete file operation not supported.");
     }
 
     @Override
     public MediaInformation getMediaInformation(String id, String type, String tenantDomain) throws
-            StorageSystemException {
+            StorageSystemServerException, StorageSystemClientException {
 
         throw new UnsupportedOperationException("Database based media information retrieval not supported.");
     }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/model/FileSecurity.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/model/FileSecurity.java
@@ -26,17 +26,17 @@ import java.util.List;
 public class FileSecurity {
 
     private boolean allowedAll;
-    private List<String> allowedUsers;
+    private List<String> allowedUserIds;
 
     public FileSecurity(boolean allowedAll) {
 
         this.allowedAll = allowedAll;
     }
 
-    public FileSecurity(boolean allowedAll, List<String> allowedUsers) {
+    public FileSecurity(boolean allowedAll, List<String> allowedUserIds) {
 
         this.allowedAll = allowedAll;
-        this.allowedUsers = allowedUsers;
+        this.allowedUserIds = allowedUserIds;
     }
 
     public boolean isAllowedAll() {
@@ -49,13 +49,13 @@ public class FileSecurity {
         this.allowedAll = allowedAll;
     }
 
-    public List<String> getAllowedUsers() {
+    public List<String> getAllowedUserIds() {
 
-        return allowedUsers;
+        return allowedUserIds;
     }
 
-    public void setAllowedUsers(List<String> allowedUsers) {
+    public void setAllowedUserIds(List<String> allowedUserIds) {
 
-        this.allowedUsers = allowedUsers;
+        this.allowedUserIds = allowedUserIds;
     }
 }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/model/MediaFileDownloadData.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/model/MediaFileDownloadData.java
@@ -27,6 +27,7 @@ public class MediaFileDownloadData {
 
     private File mediaFile;
     private String responseContentType;
+    private String etag;
 
     public File getMediaFile() {
 
@@ -46,5 +47,15 @@ public class MediaFileDownloadData {
     public void setResponseContentType(String responseContentType) {
 
         this.responseContentType = responseContentType;
+    }
+
+    public String getETag() {
+
+        return etag;
+    }
+
+    public void setETag(String etag) {
+
+        this.etag = etag;
     }
 }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/model/MediaMetadata.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/model/MediaMetadata.java
@@ -28,7 +28,7 @@ public class MediaMetadata {
     private String fileName;
     private String fileTag;
     private String fileContentType;
-    private String resourceOwner;
+    private String resourceOwnerId;
     private List<String> fileIdentifiers;
     private FileSecurity fileSecurity;
 
@@ -82,13 +82,13 @@ public class MediaMetadata {
         this.fileContentType = fileContentType;
     }
 
-    public String getResourceOwner() {
+    public String getResourceOwnerId() {
 
-        return resourceOwner;
+        return resourceOwnerId;
     }
 
-    public void setResourceOwner(String resourceOwner) {
+    public void setResourceOwnerId(String resourceOwnerId) {
 
-        this.resourceOwner = resourceOwner;
+        this.resourceOwnerId = resourceOwnerId;
     }
 }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/util/StorageSystemConstants.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/util/StorageSystemConstants.java
@@ -23,24 +23,29 @@ package org.wso2.carbon.identity.media.core.util;
 public class StorageSystemConstants {
 
     public static final String SYSTEM_PROPERTY_CARBON_HOME = "carbon.home";
-    public static final String MEDIA_STORE = "repository/media/";
-    public static final String CONFIGURABLE_UPLOAD_LOCATION = "upload.location";
+    public static final String PRE_CREATED_MEDIA_FOLDER = "media";
     public static final String METADATA_FILE_SUFFIX = "_meta";
     public static final String METADATA_FILE_EXTENSION = ".json";
     public static final String MEDIA_NAME = "name";
     public static final String MEDIA_CONTENT_TYPE = "contentType";
     public static final String MEDIA_TAG = "tag";
-    public static final String MEDIA_RESOURCE_OWNER = "resourceOwner";
+    public static final String MEDIA_RESOURCE_OWNER_ID = "resourceOwnerId";
     public static final String MEDIA_SECURITY = "security";
     public static final String MEDIA_SECURITY_ALLOWED_ALL = "allowedAll";
-    public static final String MEDIA_SECURITY_ALLOWED_USERS = "allowedUsers";
+    public static final String MEDIA_SECURITY_ALLOWED_USER_IDS = "allowedUserIds";
     public static final String PUBLIC_DOWNLOAD_ACCESS = "public";
     public static final String PROTECTED_DOWNLOAD_ACCESS = "content";
     static final String MEDIA_PROPERTIES_FILE = "META-INF/media.properties";
     static final String MEDIA_STORE_TYPE = "MediaStoreType";
-    static final String DEFAULT_MEDIA_STORE_TYPE_VALUE =
-            "org.wso2.carbon.identity.media.file.FileBasedStorageSystemImpl";
+    static final String ALLOWED_MAXIMUM_SIZE_IN_BYTES = "AllowedMaximumSizeInBytes";
     static final String ALLOWED_CONTENT_TYPES = "AllowedContentTypes";
     static final String ALLOWED_CONTENT_SUB_TYPES = ".AllowedContentSubTypes";
+    static final String MEDIA_MOUNT_LOCATION = "MediaMountLocation";
+
+    // Environment variables to override default values defined in media.properties file.
+    public static final String CONFIGURABLE_MEDIA_MOUNT_LOCATION = "MEDIA_MOUNT_LOCATION";
+    public static final String CONFIGURABLE_MAXIMUM_MEDIA_SIZE_IN_BYTES = "MEDIA_MAX_BYTE_SIZE";
+    public static final String CONFIGURABLE_MEDIA_STORE_TYPE = "MEDIA_STORE_TYPE";
+    public static final String CONFIGURABLE_MEDIA_CONTENT_TYPES = "MEDIA_CONTENT_TYPES";
 
 }

--- a/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/util/StorageSystemUtil.java
+++ b/components/org.wso2.carbon.identity.media.core/src/main/java/org/wso2/carbon/identity/media/core/util/StorageSystemUtil.java
@@ -15,9 +15,6 @@
  */
 package org.wso2.carbon.identity.media.core.util;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.media.core.exception.StorageSystemException;
 
 import java.io.IOException;
@@ -30,7 +27,8 @@ import java.util.UUID;
 
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.ALLOWED_CONTENT_SUB_TYPES;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.ALLOWED_CONTENT_TYPES;
-import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.DEFAULT_MEDIA_STORE_TYPE_VALUE;
+import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.ALLOWED_MAXIMUM_SIZE_IN_BYTES;
+import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_MOUNT_LOCATION;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_PROPERTIES_FILE;
 import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.MEDIA_STORE_TYPE;
 
@@ -39,9 +37,9 @@ import static org.wso2.carbon.identity.media.core.util.StorageSystemConstants.ME
  */
 public class StorageSystemUtil {
 
-    private static final Log LOGGER = LogFactory.getLog(StorageSystemUtil.class);
-
     private static String mediaStorageType;
+    private static String mediaMountLocation;
+    private static int mediaMaximumSize;
     private static HashMap<String, List<String>> contentTypes = new HashMap<>();
 
     public static String calculateUUID() {
@@ -54,10 +52,21 @@ public class StorageSystemUtil {
         return mediaStorageType;
     }
 
+    public static String getMediaMountLocation() {
+
+        return mediaMountLocation;
+    }
+
+    public static int getMediaMaximumSize() {
+
+        return mediaMaximumSize;
+    }
+
     public static HashMap<String, List<String>> getContentTypes() {
 
         return contentTypes;
     }
+
     /**
      * Read media properties defined in media.properties file.
      *
@@ -78,20 +87,16 @@ public class StorageSystemUtil {
                 throw new StorageSystemException("Error while loading media.properties file.", e);
             }
 
-            String mediaStoreTypeConfig = properties.getProperty(MEDIA_STORE_TYPE);
-            if (StringUtils.isNotBlank(mediaStoreTypeConfig)) {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug(String.format("The configured media store type is %s.", mediaStoreTypeConfig));
-                }
-                mediaStorageType = mediaStoreTypeConfig;
-            } else {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("MediaStoreType is not configured in media.properties file. Hence proceeding" +
-                            " with the default value: " + DEFAULT_MEDIA_STORE_TYPE_VALUE);
-                }
-                mediaStorageType = DEFAULT_MEDIA_STORE_TYPE_VALUE;
-            }
+            // Load media store type.
+            mediaStorageType = properties.getProperty(MEDIA_STORE_TYPE);
 
+            // Load media storage location (relative to CARBON_HOME).
+            mediaMountLocation = properties.getProperty(MEDIA_MOUNT_LOCATION);
+
+            // Load allowed maximum size in bytes for the media that can be uploaded.
+            mediaMaximumSize = Integer.parseInt(properties.getProperty(ALLOWED_MAXIMUM_SIZE_IN_BYTES));
+
+            // Load allowed content types.
             String[] allowedContentTypes = properties.getProperty(ALLOWED_CONTENT_TYPES).split(",");
             for (String contentType : allowedContentTypes) {
                 contentTypes.put(contentType, Arrays.asList(properties.getProperty(contentType +

--- a/components/org.wso2.carbon.identity.media.core/src/main/resources/META-INF/media.properties
+++ b/components/org.wso2.carbon.identity.media.core/src/main/resources/META-INF/media.properties
@@ -16,6 +16,11 @@
 
 MediaStoreType=org.wso2.carbon.identity.media.file.FileBasedStorageSystemImpl
 
+# relative path from CARBON_HOME
+MediaMountLocation=repository/
+
+AllowedMaximumSizeInBytes=512000
+
 AllowedContentTypes=image,text
 
 text.AllowedContentSubTypes=css

--- a/components/org.wso2.carbon.identity.media.core/src/test/java/org/wso2/carbon/identity/media/core/StorageSystemManagerTest.java
+++ b/components/org.wso2.carbon.identity.media.core/src/test/java/org/wso2/carbon/identity/media/core/StorageSystemManagerTest.java
@@ -81,8 +81,7 @@ public class StorageSystemManagerTest extends PowerMockTestCase {
         mockStatic(MediaServiceDataHolder.class);
         when(MediaServiceDataHolder.getInstance()).thenReturn(mediaServiceDataHolder);
         final String storeType = "org.wso2.carbon.identity.media.file.FileBasedStorageSystemImpl";
-        Assert.assertEquals(Whitebox.invokeMethod(storageSystemManager, "getStorageSystemFactory", storeType),
-                fileBasedStorageSystemFactory);
+        Assert.assertNotNull(Whitebox.invokeMethod(storageSystemManager, "getStorageSystem", storeType));
 
     }
 
@@ -92,8 +91,7 @@ public class StorageSystemManagerTest extends PowerMockTestCase {
         mockStatic(MediaServiceDataHolder.class);
         when(MediaServiceDataHolder.getInstance()).thenReturn(mediaServiceDataHolder);
         final String storeType = "org.wso2.carbon.identity.media.jdbc.DatabaseBasedStorageSystemImpl";
-        Assert.assertEquals(Whitebox.invokeMethod(storageSystemManager, "getStorageSystemFactory", storeType),
-                databaseBasedStorageSystemFactory);
+        Assert.assertNotNull(Whitebox.invokeMethod(storageSystemManager, "getStorageSystem", storeType));
 
     }
 
@@ -103,7 +101,7 @@ public class StorageSystemManagerTest extends PowerMockTestCase {
         mockStatic(MediaServiceDataHolder.class);
         when(MediaServiceDataHolder.getInstance()).thenReturn(mediaServiceDataHolder);
         final String storeType = "org.wso2.carbon.identity.media.incorrect.IncorrectStorageSystemImpl";
-        Assert.assertNull(Whitebox.invokeMethod(storageSystemManager, "getStorageSystemFactory", storeType));
+        Assert.assertNull(Whitebox.invokeMethod(storageSystemManager, "getStorageSystem", storeType));
 
     }
 
@@ -114,7 +112,7 @@ public class StorageSystemManagerTest extends PowerMockTestCase {
         when(MediaServiceDataHolder.getInstance()).thenReturn(mediaServiceDataHolder);
 
         FileBasedStorageSystemImpl fileBasedStorageSystem = mock(FileBasedStorageSystemImpl.class);
-        when(fileBasedStorageSystemFactory.getInstance()).thenReturn(fileBasedStorageSystem);
+        when(fileBasedStorageSystemFactory.getStorageSystem()).thenReturn(fileBasedStorageSystem);
 
         mockStatic(StorageSystemUtil.class);
         String mockUUID = "30d0325e-40bc-45f3-845e-f13dd130e963";
@@ -175,7 +173,7 @@ public class StorageSystemManagerTest extends PowerMockTestCase {
         mockStatic(MediaServiceDataHolder.class);
         when(MediaServiceDataHolder.getInstance()).thenReturn(mediaServiceDataHolder);
         FileBasedStorageSystemImpl fileBasedStorageSystem = mock(FileBasedStorageSystemImpl.class);
-        when(fileBasedStorageSystemFactory.getInstance()).thenReturn(fileBasedStorageSystem);
+        when(fileBasedStorageSystemFactory.getStorageSystem()).thenReturn(fileBasedStorageSystem);
 
         mockStatic(StorageSystemUtil.class);
         String mockstoreType = "org.wso2.carbon.identity.media.file.FileBasedStorageSystemImpl";

--- a/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/ContentApi.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/ContentApi.java
@@ -54,6 +54,7 @@ public class ContentApi  {
     }, tags={ "Download Media" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "File downloaded successfully.", response = File.class),
+        @ApiResponse(code = 304, message = "Not Modified. Empty body because the client has already the latest version of the requested resource.", response = Void.class),
         @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
         @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
         @ApiResponse(code = 401, message = "Authentication information is missing or invalid.", response = Void.class),
@@ -61,9 +62,9 @@ public class ContentApi  {
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class),
         @ApiResponse(code = 501, message = "Not implemented.", response = Error.class)
     })
-    public Response downloadMedia(@ApiParam(value = "The media type.",required=true) @PathParam("type") String type, @ApiParam(value = "Unique identifier for the file.",required=true) @PathParam("id") String id,     @Valid@ApiParam(value = "")  @QueryParam("identifier") String identifier) {
+    public Response downloadMedia(@ApiParam(value = "The media type.",required=true) @PathParam("type") String type, @ApiParam(value = "Unique identifier for the file.",required=true) @PathParam("id") String id,     @Valid@ApiParam(value = "")  @QueryParam("identifier") String identifier,     @Valid @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved variant of the resource." )@HeaderParam("If-None-Match") String ifNoneMatch) {
 
-        return delegate.downloadMedia(type,  id,  identifier );
+        return delegate.downloadMedia(type,  id,  identifier,  ifNoneMatch );
     }
 
 }

--- a/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/ContentApiService.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/ContentApiService.java
@@ -29,5 +29,5 @@ import javax.ws.rs.core.Response;
 
 public interface ContentApiService {
 
-      public Response downloadMedia(String type, String id, String identifier);
+      public Response downloadMedia(String type, String id, String identifier, String ifNoneMatch);
 }

--- a/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/MultipleFilesUploadResponseLinks.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/MultipleFilesUploadResponseLinks.java
@@ -61,7 +61,7 @@ public class MultipleFilesUploadResponseLinks  {
         return this;
     }
     
-    @ApiModelProperty(example = "/t/carbon.super/api/identity/media/v1.0/content/image/6e41cb95-c3b3-4e6c-928a-acb1b88e991d?identifier=large", value = "Location of the uploaded sub resource.")
+    @ApiModelProperty(example = "/t/carbon.super/api/identity/media/v1.0/content/image/20201012-6e41cb95-c3b3-4e6c-928a-acb1b88e991d?identifier=large", value = "Location of the uploaded sub resource.")
     @JsonProperty("href")
     @Valid
     public String getHref() {

--- a/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/PrivilegedUserSecurity.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/PrivilegedUserSecurity.java
@@ -35,7 +35,7 @@ import javax.xml.bind.annotation.*;
 public class PrivilegedUserSecurity  {
   
     private Boolean allowedAll;
-    private List<String> allowedUsers = null;
+    private List<String> allowedUserIds = null;
 
 
     /**
@@ -58,29 +58,29 @@ public class PrivilegedUserSecurity  {
     }
 
     /**
-    * The set of users entitled to access the file.
+    * The ids of set of users entitled to access the file.
     **/
-    public PrivilegedUserSecurity allowedUsers(List<String> allowedUsers) {
+    public PrivilegedUserSecurity allowedUserIds(List<String> allowedUserIds) {
 
-        this.allowedUsers = allowedUsers;
+        this.allowedUserIds = allowedUserIds;
         return this;
     }
     
-    @ApiModelProperty(example = "[\"user1\",\"user2\"]", value = "The set of users entitled to access the file.")
-    @JsonProperty("allowedUsers")
+    @ApiModelProperty(example = "[\"de0f7994-eb83-4cd9-96db-52cb62a1feaf\",\"fcb1940b-d669-4c58-8292-e8bca0f606b4\"]", value = "The ids of set of users entitled to access the file.")
+    @JsonProperty("allowedUserIds")
     @Valid
-    public List<String> getAllowedUsers() {
-        return allowedUsers;
+    public List<String> getAllowedUserIds() {
+        return allowedUserIds;
     }
-    public void setAllowedUsers(List<String> allowedUsers) {
-        this.allowedUsers = allowedUsers;
+    public void setAllowedUserIds(List<String> allowedUserIds) {
+        this.allowedUserIds = allowedUserIds;
     }
 
-    public PrivilegedUserSecurity addAllowedUsersItem(String allowedUsersItem) {
-        if (this.allowedUsers == null) {
-            this.allowedUsers = new ArrayList<>();
+    public PrivilegedUserSecurity addAllowedUserIdsItem(String allowedUserIdsItem) {
+        if (this.allowedUserIds == null) {
+            this.allowedUserIds = new ArrayList<>();
         }
-        this.allowedUsers.add(allowedUsersItem);
+        this.allowedUserIds.add(allowedUserIdsItem);
         return this;
     }
 
@@ -97,12 +97,12 @@ public class PrivilegedUserSecurity  {
         }
         PrivilegedUserSecurity privilegedUserSecurity = (PrivilegedUserSecurity) o;
         return Objects.equals(this.allowedAll, privilegedUserSecurity.allowedAll) &&
-            Objects.equals(this.allowedUsers, privilegedUserSecurity.allowedUsers);
+            Objects.equals(this.allowedUserIds, privilegedUserSecurity.allowedUserIds);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(allowedAll, allowedUsers);
+        return Objects.hash(allowedAll, allowedUserIds);
     }
 
     @Override
@@ -112,7 +112,7 @@ public class PrivilegedUserSecurity  {
         sb.append("class PrivilegedUserSecurity {\n");
         
         sb.append("    allowedAll: ").append(toIndentedString(allowedAll)).append("\n");
-        sb.append("    allowedUsers: ").append(toIndentedString(allowedUsers)).append("\n");
+        sb.append("    allowedUserIds: ").append(toIndentedString(allowedUserIds)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/PrivilegedUserSecurityAllOf.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/PrivilegedUserSecurityAllOf.java
@@ -32,33 +32,33 @@ import javax.xml.bind.annotation.*;
 
 public class PrivilegedUserSecurityAllOf  {
   
-    private List<String> allowedUsers = null;
+    private List<String> allowedUserIds = null;
 
 
     /**
-    * The set of users entitled to access the file.
+    * The ids of set of users entitled to access the file.
     **/
-    public PrivilegedUserSecurityAllOf allowedUsers(List<String> allowedUsers) {
+    public PrivilegedUserSecurityAllOf allowedUserIds(List<String> allowedUserIds) {
 
-        this.allowedUsers = allowedUsers;
+        this.allowedUserIds = allowedUserIds;
         return this;
     }
     
-    @ApiModelProperty(example = "[\"user1\",\"user2\"]", value = "The set of users entitled to access the file.")
-    @JsonProperty("allowedUsers")
+    @ApiModelProperty(example = "[\"de0f7994-eb83-4cd9-96db-52cb62a1feaf\",\"fcb1940b-d669-4c58-8292-e8bca0f606b4\"]", value = "The ids of set of users entitled to access the file.")
+    @JsonProperty("allowedUserIds")
     @Valid
-    public List<String> getAllowedUsers() {
-        return allowedUsers;
+    public List<String> getAllowedUserIds() {
+        return allowedUserIds;
     }
-    public void setAllowedUsers(List<String> allowedUsers) {
-        this.allowedUsers = allowedUsers;
+    public void setAllowedUserIds(List<String> allowedUserIds) {
+        this.allowedUserIds = allowedUserIds;
     }
 
-    public PrivilegedUserSecurityAllOf addAllowedUsersItem(String allowedUsersItem) {
-        if (this.allowedUsers == null) {
-            this.allowedUsers = new ArrayList<>();
+    public PrivilegedUserSecurityAllOf addAllowedUserIdsItem(String allowedUserIdsItem) {
+        if (this.allowedUserIds == null) {
+            this.allowedUserIds = new ArrayList<>();
         }
-        this.allowedUsers.add(allowedUsersItem);
+        this.allowedUserIds.add(allowedUserIdsItem);
         return this;
     }
 
@@ -74,12 +74,12 @@ public class PrivilegedUserSecurityAllOf  {
             return false;
         }
         PrivilegedUserSecurityAllOf privilegedUserSecurityAllOf = (PrivilegedUserSecurityAllOf) o;
-        return Objects.equals(this.allowedUsers, privilegedUserSecurityAllOf.allowedUsers);
+        return Objects.equals(this.allowedUserIds, privilegedUserSecurityAllOf.allowedUserIds);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(allowedUsers);
+        return Objects.hash(allowedUserIds);
     }
 
     @Override
@@ -88,7 +88,7 @@ public class PrivilegedUserSecurityAllOf  {
         StringBuilder sb = new StringBuilder();
         sb.append("class PrivilegedUserSecurityAllOf {\n");
         
-        sb.append("    allowedUsers: ").append(toIndentedString(allowedUsers)).append("\n");
+        sb.append("    allowedUserIds: ").append(toIndentedString(allowedUserIds)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/PublicApi.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/PublicApi.java
@@ -49,14 +49,15 @@ public class PublicApi  {
     @ApiOperation(value = "Download a publicly available file.", notes = "", response = File.class, tags={ "Download Media" })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "File downloaded successfully.", response = File.class),
+        @ApiResponse(code = 304, message = "Not Modified. Empty body because the client has already the latest version of the requested resource.", response = Void.class),
         @ApiResponse(code = 400, message = "Invalid input in the request.", response = Error.class),
         @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class),
         @ApiResponse(code = 501, message = "Not implemented.", response = Error.class)
     })
-    public Response downloadPublicMedia(@ApiParam(value = "The media type.",required=true) @PathParam("type") String type, @ApiParam(value = "Unique identifier for the file.",required=true) @PathParam("id") String id,     @Valid@ApiParam(value = "")  @QueryParam("identifier") String identifier) {
+    public Response downloadPublicMedia(@ApiParam(value = "The media type.",required=true) @PathParam("type") String type, @ApiParam(value = "Unique identifier for the file.",required=true) @PathParam("id") String id,     @Valid@ApiParam(value = "")  @QueryParam("identifier") String identifier,     @Valid @ApiParam(value = "Validator for conditional requests; based on the ETag of the formerly retrieved variant of the resource." )@HeaderParam("If-None-Match") String ifNoneMatch) {
 
-        return delegate.downloadPublicMedia(type,  id,  identifier );
+        return delegate.downloadPublicMedia(type,  id,  identifier,  ifNoneMatch );
     }
 
 }

--- a/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/PublicApiService.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/gen/java/org/wso2/carbon/identity/media/endpoint/PublicApiService.java
@@ -29,5 +29,5 @@ import javax.ws.rs.core.Response;
 
 public interface PublicApiService {
 
-      public Response downloadPublicMedia(String type, String id, String identifier);
+      public Response downloadPublicMedia(String type, String id, String identifier, String ifNoneMatch);
 }

--- a/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/common/MediaServiceConstants.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/common/MediaServiceConstants.java
@@ -54,6 +54,8 @@ public class MediaServiceConstants {
                 "File with id: %s not found for media type: %s"),
         ERROR_CODE_ERROR_UNSUPPORTED_CONTENT_TYPE_PATH_PARAM("60007", "Unable to perform the requested media" +
                 " operation.", "Unsupported file content type available as a path parameter in the request."),
+        ERROR_CODE_INVALID_MEDIA_SIZE("60008", "Unable to upload the provided media.",
+                "Media size exceeds the maximum allowed size."),
 
         // Server errors.
         ERROR_CODE_ERROR_UPLOADING_MEDIA("65001", "Unable to upload the provided media.",
@@ -72,7 +74,9 @@ public class MediaServiceConstants {
         ERROR_CODE_ERROR_BUILDING_RESPONSE_HEADER_URL("65007", "Unable to build uploaded media location URL.",
                 "Server encountered an error while building URL for response header."),
         ERROR_CODE_ERROR_RETRIEVING_STORAGE_SYSTEM_MANAGER("65008", "Unable to fulfill the request.",
-                "Server encountered an error while retrieving StorageSystemManager.");
+                "Server encountered an error while retrieving StorageSystemManager."),
+        ERROR_CODE_ERROR_CALCULATING_MEDIA_SIZE("65009", "Unable to upload the provided media.",
+                "Server encountered an error while calculating media size.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/common/Util.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/common/Util.java
@@ -96,7 +96,7 @@ public class Util {
     public static MediaEndpointException handleException(Exception e, MediaServiceConstants.ErrorMessage errorMessage,
                                                          Log log, Response.Status status, String... data) {
 
-        Error error = buildError(errorMessage, log, e, errorMessage.getDescription(), data);
+        Error error = buildError(errorMessage, log, e, data);
         return new MediaEndpointException(status, error);
     }
 
@@ -111,29 +111,28 @@ public class Util {
 
         Error error = new Error();
         error.setCode(errorMessage.getCode());
-        error.setDescription(buildErrorDescription(errorMessage, data));
+        error.setDescription(buildErrorDescription(errorMessage.getDescription(), data));
         error.setMessage(errorMessage.getMessage());
         error.setTraceId(getCorrelation());
         return error;
     }
 
-    private static String buildErrorDescription(MediaServiceConstants.ErrorMessage errorMessage, String... data) {
+    private static String buildErrorDescription(String errorDescription, String... data) {
 
-        String errorDescription;
         if (ArrayUtils.isNotEmpty(data)) {
-            errorDescription = String.format(errorMessage.getDescription(), data);
+            return String.format(errorDescription, data);
         } else {
-            errorDescription = errorMessage.getDescription();
+            return errorDescription;
         }
-        return errorDescription;
     }
 
     private static Error buildError(MediaServiceConstants.ErrorMessage errorMessage, Log log, Exception e,
-                                    String message, String... data) {
+                                    String... data) {
 
         Error error = getError(errorMessage, data);
         String errorMessageFormat = "errorCode: %s | message: %s";
-        String errorMsg = String.format(errorMessageFormat, error.getCode(), message);
+        String errorMsg = String.format(errorMessageFormat, error.getCode(),
+                buildErrorDescription(errorMessage.getDescription(), data));
         log.error(errorMsg, e);
         return error;
     }

--- a/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/impl/ContentApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/impl/ContentApiServiceImpl.java
@@ -31,8 +31,8 @@ public class ContentApiServiceImpl implements ContentApiService {
     private MediaService mediaService;
 
     @Override
-    public Response downloadMedia(String type, String id, String identifier) {
+    public Response downloadMedia(String type, String id, String identifier, String ifNoneMatch) {
 
-        return mediaService.downloadMediaFile(type, id, identifier);
+        return mediaService.downloadMediaFile(type, id, identifier, ifNoneMatch);
     }
 }

--- a/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/impl/MeApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/impl/MeApiServiceImpl.java
@@ -57,11 +57,13 @@ public class MeApiServiceImpl implements MeApiService {
     public Response uploadMedia(String type, List<InputStream> filesInputStream, List<Attachment> filesDetail,
                                 Metadata metadata) {
 
-        mediaService.validateFileUploadMediaTypes(type, filesDetail.get(0).getContentType());
         // Only single file upload will be supported in the first phase of the implementation.
         if (filesInputStream.size() > 1) {
             return Response.status(Response.Status.NOT_IMPLEMENTED).build();
         } else {
+            mediaService.validateFileUploadMediaTypes(type, filesDetail.get(0).getContentType());
+            mediaService.validateFileSize(filesInputStream.get(0));
+
             String uuid = mediaService.uploadMedia(filesInputStream, filesDetail, metadata);
 
             String mediaAccessLevel;

--- a/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/impl/PublicApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/impl/PublicApiServiceImpl.java
@@ -31,8 +31,8 @@ public class PublicApiServiceImpl implements PublicApiService {
     private MediaService mediaService;
 
     @Override
-    public Response downloadPublicMedia(String type, String id, String identifier) {
+    public Response downloadPublicMedia(String type, String id, String identifier, String ifNoneMatch) {
 
-        return mediaService.downloadMediaFile(type, id, identifier);
+        return mediaService.downloadMediaFile(type, id, identifier, ifNoneMatch);
     }
 }

--- a/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/impl/UserApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/impl/UserApiServiceImpl.java
@@ -50,11 +50,13 @@ public class UserApiServiceImpl implements UserApiService {
     public Response privilegedUserUploadMedia(String type, List<InputStream> filesInputStream,
                                               List<Attachment> filesDetail, PrivilegedUserMetadata metadata) {
 
-        mediaService.validateFileUploadMediaTypes(type, filesDetail.get(0).getContentType());
         // Only single file upload will be supported in the first phase of the implementation.
         if (filesInputStream.size() > 1) {
             return Response.status(Response.Status.NOT_IMPLEMENTED).build();
         } else {
+            mediaService.validateFileUploadMediaTypes(type, filesDetail.get(0).getContentType());
+            mediaService.validateFileSize(filesInputStream.get(0));
+
             String uuid = mediaService.uploadPrivilegedUserMedia(filesInputStream, filesDetail, metadata);
 
             String mediaAccessLevel;

--- a/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/service/MediaService.java
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/main/java/org/wso2/carbon/identity/media/endpoint/service/MediaService.java
@@ -27,6 +27,7 @@ import org.wso2.carbon.identity.media.core.FileContent;
 import org.wso2.carbon.identity.media.core.StorageSystemManager;
 import org.wso2.carbon.identity.media.core.StreamContent;
 import org.wso2.carbon.identity.media.core.exception.StorageSystemClientException;
+import org.wso2.carbon.identity.media.core.exception.StorageSystemException;
 import org.wso2.carbon.identity.media.core.exception.StorageSystemServerException;
 import org.wso2.carbon.identity.media.core.model.FileSecurity;
 import org.wso2.carbon.identity.media.core.model.MediaInformation;
@@ -229,13 +230,14 @@ public class MediaService {
         StorageSystemManager storageSystemManager = getStorageSystemManager();
         try {
             storageSystemManager.validateMediaSize(inputStream);
-        } catch (StorageSystemClientException e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Unable to upload the provided media.", e);
+        } catch (StorageSystemException e) {
+            if (e instanceof StorageSystemClientException) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Unable to upload the provided media.", e);
+                }
+                throw handleException(Response.Status.BAD_REQUEST,
+                        MediaServiceConstants.ErrorMessage.ERROR_CODE_INVALID_MEDIA_SIZE);
             }
-            throw handleException(Response.Status.BAD_REQUEST,
-                    MediaServiceConstants.ErrorMessage.ERROR_CODE_INVALID_MEDIA_SIZE);
-        } catch (StorageSystemServerException e) {
             MediaServiceConstants.ErrorMessage errorMessage = MediaServiceConstants.ErrorMessage.
                     ERROR_CODE_ERROR_CALCULATING_MEDIA_SIZE;
             Response.Status status = Response.Status.INTERNAL_SERVER_ERROR;
@@ -286,13 +288,14 @@ public class MediaService {
         String tenantDomain = getTenantDomainFromContext();
         try {
             return storageSystemManager.readContent(id, tenantDomain, type);
-        } catch (StorageSystemClientException e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Media download request can't be performed.", e);
+        } catch (StorageSystemException e) {
+            if (e instanceof StorageSystemClientException) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Media download request can't be performed.", e);
+                }
+                throw handleException(Response.Status.NOT_FOUND,
+                        MediaServiceConstants.ErrorMessage.ERROR_CODE_ERROR_DOWNLOADING_MEDIA_FILE_NOT_FOUND, id);
             }
-            throw handleException(Response.Status.NOT_FOUND,
-                    MediaServiceConstants.ErrorMessage.ERROR_CODE_ERROR_DOWNLOADING_MEDIA_FILE_NOT_FOUND, id);
-        } catch (StorageSystemServerException e) {
             MediaServiceConstants.ErrorMessage errorMessage = MediaServiceConstants.ErrorMessage.
                     ERROR_CODE_ERROR_DOWNLOADING_MEDIA;
             Response.Status status = Response.Status.INTERNAL_SERVER_ERROR;
@@ -333,13 +336,14 @@ public class MediaService {
         String tenantDomain = getTenantDomainFromContext();
         try {
             storageSystemManager.deleteMedia(id, type, tenantDomain);
-        } catch (StorageSystemClientException e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Client exception while deleting media.", e);
+        } catch (StorageSystemException e) {
+            if (e instanceof StorageSystemClientException) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Client exception while deleting media.", e);
+                }
+                throw handleException(Response.Status.NOT_FOUND,
+                        MediaServiceConstants.ErrorMessage.ERROR_CODE_ERROR_DELETING_MEDIA_FILE_NOT_FOUND, id, type);
             }
-            throw handleException(Response.Status.NOT_FOUND,
-                    MediaServiceConstants.ErrorMessage.ERROR_CODE_ERROR_DELETING_MEDIA_FILE_NOT_FOUND, id, type);
-        } catch (StorageSystemServerException e) {
             MediaServiceConstants.ErrorMessage errorMessage = MediaServiceConstants.ErrorMessage.
                     ERROR_CODE_ERROR_DELETING_MEDIA;
             Response.Status status = Response.Status.INTERNAL_SERVER_ERROR;
@@ -363,14 +367,15 @@ public class MediaService {
 
         try {
             return storageSystemManager.retrieveMediaInformation(id, type, tenantDomain);
-        } catch (StorageSystemClientException e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Unable to retrieve requested media information.", e);
+        } catch (StorageSystemException e) {
+            if (e instanceof StorageSystemClientException) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Unable to retrieve requested media information.", e);
+                }
+                throw handleException(Response.Status.NOT_FOUND,
+                        MediaServiceConstants.ErrorMessage.ERROR_CODE_ERROR_RETRIEVING_MEDIA_INFORMATION_FILE_NOT_FOUND,
+                        id);
             }
-            throw handleException(Response.Status.NOT_FOUND,
-                    MediaServiceConstants.ErrorMessage.ERROR_CODE_ERROR_RETRIEVING_MEDIA_INFORMATION_FILE_NOT_FOUND,
-                    id);
-        } catch (StorageSystemServerException e) {
             MediaServiceConstants.ErrorMessage errorMessage = MediaServiceConstants.ErrorMessage.
                     ERROR_CODE_ERROR_RETRIEVING_MEDIA_INFORMATION;
             Response.Status status = Response.Status.INTERNAL_SERVER_ERROR;

--- a/components/org.wso2.carbon.identity.media.endpoint/src/main/resources/media_endpoint.yaml
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/main/resources/media_endpoint.yaml
@@ -296,7 +296,7 @@ components:
       required: true
       schema:
         type: string
-      example: 6e41cb95-c3b3-4e6c-928a-acb1b88e991d
+      example: 20201012-6e41cb95-c3b3-4e6c-928a-acb1b88e991d
     typeParam:
       in: path
       name: type
@@ -368,8 +368,8 @@ components:
         - $ref: '#/components/schemas/Security'
         - type: object
           properties:
-            allowedUsers:
-              $ref: '#/components/schemas/AllowedUsers'
+            allowedUserIds:
+              $ref: '#/components/schemas/AllowedUserIds'
 
     Tag:
       type: string
@@ -381,12 +381,12 @@ components:
       description: Defines whether the file is publicly available for access or has restricted access.
       example: false
 
-    AllowedUsers:
+    AllowedUserIds:
       type: array
-      description: The set of users entitled to access the file.
+      description: The ids of set of users entitled to access the file.
       items:
         type: string
-      example: ['user1', 'user2']
+      example: ['de0f7994-eb83-4cd9-96db-52cb62a1feaf', 'fcb1940b-d669-4c58-8292-e8bca0f606b4']
 
     Identifiers:
       type: array
@@ -411,7 +411,7 @@ components:
                 description: Identifier for the sub resource.
               href:
                 type: string
-                example: '/t/carbon.super/api/identity/media/v1.0/content/image/6e41cb95-c3b3-4e6c-928a-acb1b88e991d?identifier=large'
+                example: '/t/carbon.super/api/identity/media/v1.0/content/image/20201012-6e41cb95-c3b3-4e6c-928a-acb1b88e991d?identifier=large'
                 description: Location of the uploaded sub resource.
 
     MediaInformationResponse:

--- a/components/org.wso2.carbon.identity.media.endpoint/src/main/resources/media_endpoint.yaml
+++ b/components/org.wso2.carbon.identity.media.endpoint/src/main/resources/media_endpoint.yaml
@@ -113,6 +113,7 @@ paths:
           example: 'medium'
         - $ref: '#/components/parameters/typeParam'
         - $ref: '#/components/parameters/idParam'
+        - $ref: '#/components/parameters/If-None-Match'
       responses:
         '200':
           description: File downloaded successfully.
@@ -123,10 +124,16 @@ paths:
             Cache-Control:
               schema:
                 type: string
+            ETag:
+              description: Entity Tag of the response resource. Used by caches, or in conditional requests.
+              schema:
+                type: string
           content:
             application/octet-stream:
               schema:
                 $ref: '#/components/schemas/DownloadFile'
+        '304':
+          $ref: '#/components/responses/NotModified'
         '400':
           $ref: '#/components/responses/BadRequest'
         '404':
@@ -154,6 +161,7 @@ paths:
           example: 'medium'
         - $ref: '#/components/parameters/typeParam'
         - $ref: '#/components/parameters/idParam'
+        - $ref: '#/components/parameters/If-None-Match'
       responses:
         '200':
           description: File downloaded successfully.
@@ -164,10 +172,16 @@ paths:
             Cache-Control:
               schema:
                 type: string
+            ETag:
+              description: Entity Tag of the response resource. Used by caches, or in conditional requests.
+              schema:
+                type: string
           content:
             application/octet-stream:
               schema:
                 $ref: '#/components/schemas/DownloadFile'
+        '304':
+          $ref: '#/components/responses/NotModified'
         '400':
           $ref: '#/components/responses/BadRequest'
         '404':
@@ -305,6 +319,16 @@ components:
       schema:
         type: string
       example: image
+
+    # The HTTP If-None-Match header
+    # Used to avoid retrieving data that are already cached
+    If-None-Match:
+      name: If-None-Match
+      in: header
+      description: Validator for conditional requests; based on the ETag of the formerly retrieved variant of the resource.
+      schema:
+        type: string
+      example: f88dd058fe004909615a64f01be66a7
 
   schemas:
     # Multiple file uploads will not be supported in the first phase of the implementation.
@@ -465,6 +489,8 @@ components:
       description: Authentication information is missing or invalid.
     Forbidden:
       description: Access forbidden.
+    NotModified:
+      description: Not Modified. Empty body because the client has already the latest version of the requested resource.
     ServerError:
       description: Internal server error.
       content:

--- a/pom.xml
+++ b/pom.xml
@@ -337,8 +337,7 @@
         <!-- Pax Logging Version -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
         <!-- kernel version -->
-        <carbon.kernel.version>4.5.0</carbon.kernel.version>
-        <carbon.kernel.feature.version>4.5.0</carbon.kernel.feature.version>
+        <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <identity.media.core.exp.pkg.version>${project.version}</identity.media.core.exp.pkg.version>
         <carbon.identity.framework.version>5.17.66</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)
@@ -346,7 +345,8 @@
         <org.wso2.carbon.identity.media.core.imp.pkg.version.range>[2.0.0,3.0.0)</org.wso2.carbon.identity.media.core.imp.pkg.version.range>
         <org.wso2.carbon.identity.auth.service.version>1.4.6</org.wso2.carbon.identity.auth.service.version>
         <json-simple.version>1.1.wso2v1</json-simple.version>
-        <user.core.imp.pkg.version.range>[4.5,5)</user.core.imp.pkg.version.range>
+        <user.core.imp.pkg.version.range>[4.6.0,5.0.0)</user.core.imp.pkg.version.range>
+        <carbon.user.api.imp.pkg.version.range>[1.0.1,2.0.0)</carbon.user.api.imp.pkg.version.range>
         <org.apache.commons.io.imp.pkg.version.range>[2.4,3)</org.apache.commons.io.imp.pkg.version.range>
         <org.apache.commons.codec.imp.pkg.version.range>[1.4,2)</org.apache.commons.codec.imp.pkg.version.range>
         <org.apache.commons.lang.imp.pkg.version.range>[2.6,3)</org.apache.commons.lang.imp.pkg.version.range>


### PR DESCRIPTION
This PR adds the following improvements:

- Add the capability to override the properties defined in the media.properties file via environment variables.
- Introduce a configuration to define the maximum allowed byte size of the media to be uploaded. The default value would 512 KB.
- Have the 'yyyyMMdd' date format (of the media uploaded date) appended to the unique id of the media and incorporate this when creating the hierarchical folder structure.
- Enforce user to manually create a directory called 'media' in the media mount location. This decision was taken as an additional safety measure to prevent files from being stored in an incorrect location. 
- Have user id instead of the username.
- Add ETag support for media download API.